### PR TITLE
Improve TRL compatibility

### DIFF
--- a/openfasoc/generators/glayout/glayout/llm/train_and_run.py
+++ b/openfasoc/generators/glayout/glayout/llm/train_and_run.py
@@ -282,15 +282,38 @@ def run_full_SFT_training(model: str, accesstoken: str) -> tuple:
     #         with open(split+".txt","a") as datafile:
     #             datafile.write(ele["messages"][1]["content"].split("\n")[0]+"\n")
     #import pdb ; pdb.set_trace()
-    trainer = SFTTrainer(
-        model=model,
-        tokenizer=tokenizer,
-        args=training_args,
-        train_dataset=data["train"],
-        eval_dataset=data["evaluation"],
-        max_seq_length=4096,
-        data_collator=data_collator
-    )# add context to all glayout prompts
+    try:
+        trainer = SFTTrainer(
+            model=model,
+            tokenizer=tokenizer,
+            args=training_args,
+            train_dataset=data["train"],
+            eval_dataset=data["evaluation"],
+            max_seq_length=4096,
+            data_collator=data_collator,
+        )
+    except TypeError:
+        # older versions of TRL's SFTTrainer may not accept the `tokenizer`
+        # or `max_seq_length` arguments. Try progressively simpler calls for
+        # compatibility with a wide range of versions.
+        try:
+            trainer = SFTTrainer(
+                model=model,
+                args=training_args,
+                train_dataset=data["train"],
+                eval_dataset=data["evaluation"],
+                max_seq_length=4096,
+                data_collator=data_collator,
+            )
+        except TypeError:
+            trainer = SFTTrainer(
+                model=model,
+                args=training_args,
+                train_dataset=data["train"],
+                eval_dataset=data["evaluation"],
+                data_collator=data_collator,
+            )
+    # add context to all glayout prompts
     trainer.train()
     model.save_pretrained(output_dir / "checkpoint-bestperf")
     model.eval()


### PR DESCRIPTION
## Summary
- make `run_full_SFT_training` more robust to different TRL versions
  - retry SFTTrainer init without `tokenizer`
  - retry once more without `max_seq_length`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mako')*
- `pip install mako` *(fails: could not connect to proxy)*
