### PR TITLE
Set default grid size for mapped PDKs

### DIFF
--- a/openfasoc/generators/glayout/README.md
+++ b/openfasoc/generators/glayout/README.md
@@ -180,6 +180,9 @@ The [PortTree](https://github.com/alibillalhammoud/OpenFASOC/blob/main/openfasoc
 
 ### Snap to 2x grid
 All rules (when creating a MappedPDK) and all user provided float arguments must be snapped to 2*grid size. This is because it is possible to center a component. Centering a component which has a dimension on grid may result in off grid polygons. You can snap floating point values to grid easily by calling `pdk.snap_to_2x_grid()`. You should also take care to snap to 2xgrid whenever you see it is neccessary while writing generator code. For example, most generators which take a size(xdim: float, ydim: float) argument should snap to 2xgrid.
+The `gf180_mapped` and `sky130_mapped` PDK modules initialize their `grid_size`
+to `1e-3` and, when imported, update `gdsfactory.config.CONF.grid_size`
+accordingly. This ensures a consistent snap-to-grid behavior across layouts.
 ### Mimcaps Implementation
 Although many technolgies have 2 or more mimcap options, there is currently only 1 mimcap option supported. When creating a mapped pdk, you specify the cap metal layer as a generic layer, but you specify the metal above and metal below the cap met as part of the DRC rule set for `pdk.get_grule("capmet")`. You can access the metal above capmet with `pdk.get_grule(capmet)["capmettop"]`.
 ### DRC

--- a/openfasoc/generators/glayout/glayout/flow/pdk/gf180_mapped/gf180_mapped.py
+++ b/openfasoc/generators/glayout/glayout/flow/pdk/gf180_mapped/gf180_mapped.py
@@ -5,6 +5,7 @@ usage: from gf180_mapped import gf180_mapped_pdk
 from ..gf180_mapped.grules import grulesobj
 from ..mappedpdk import MappedPDK, SetupPDKFiles
 from pathlib import Path
+import gdsfactory.config as gf_config
 
 # Actual Pin definations for GlobalFoundries 180nmMCU from the PDK manual
 # Ref: https://gf180mcu-pdk.readthedocs.io/en/latest/
@@ -102,16 +103,21 @@ pdk_files = SetupPDKFiles(
 gf180_mapped_pdk = MappedPDK(
     name="gf180",
     glayers=gf180_glayer_mapping,
-	models={
+        models={
         'nfet': 'nfet_03v3',
-		'pfet': 'pfet_03v3',
-		'mimcap': 'mimcap_1p0fF'
+                'pfet': 'pfet_03v3',
+                'mimcap': 'mimcap_1p0fF'
     },
     layers=LAYER,
     pdk_files=pdk_files,
     grules=grulesobj,
 )
 
-# configure the grid size and other settings
+# set grid size and propagate to gdsfactory config if not already defined
+gf180_mapped_pdk.grid_size = 1e-3
+if not hasattr(gf_config.CONF, "grid_size"):
+    gf_config.CONF.grid_size = gf180_mapped_pdk.grid_size
+
+# configure gds settings
 gf180_mapped_pdk.gds_write_settings.precision = 5*10**-9
-gf180_mapped_pdk.cell_decorator_settings.cache=False
+gf180_mapped_pdk.cell_decorator_settings.cache = False

--- a/openfasoc/generators/glayout/glayout/flow/pdk/sky130_mapped/sky130_mapped.py
+++ b/openfasoc/generators/glayout/glayout/flow/pdk/sky130_mapped/sky130_mapped.py
@@ -6,6 +6,7 @@ from ..mappedpdk import MappedPDK, SetupPDKFiles
 from ..sky130_mapped.grules import grulesobj
 from pathlib import Path
 from ..sky130_mapped.sky130_add_npc import sky130_add_npc
+import gdsfactory.config as gf_config
 
 # Actual Pin definations for Skywater 130nm from the PDK manual
 # Ref: https://skywater-pdk.readthedocs.io/en/main/rules/layers.html#layers-definitions
@@ -128,17 +129,21 @@ pdk_files = SetupPDKFiles(
 sky130_mapped_pdk = MappedPDK(
     name="sky130",
     glayers=sky130_glayer_mapping,
-	models={
+        models={
         'nfet': 'sky130_fd_pr__nfet_01v8',
-		'pfet': 'sky130_fd_pr__pfet_01v8',
-		'mimcap': 'sky130_fd_pr__cap_mim_m3_1'
+                'pfet': 'sky130_fd_pr__pfet_01v8',
+                'mimcap': 'sky130_fd_pr__cap_mim_m3_1'
     },
     layers=LAYER,
     grules=grulesobj,
     pdk_files=pdk_files,
     default_decorator=sky130_add_npc
 )
-# set the grid size
+# set grid size and propagate to gdsfactory config if not already defined
+sky130_mapped_pdk.grid_size = 1e-3
+if not hasattr(gf_config.CONF, "grid_size"):
+    gf_config.CONF.grid_size = sky130_mapped_pdk.grid_size
+# configure gds settings
 sky130_mapped_pdk.gds_write_settings.precision = 5*10**-9
 sky130_mapped_pdk.cell_decorator_settings.cache=False
 sky130_mapped_pdk.gds_write_settings.flatten_invalid_refs=False


### PR DESCRIPTION
## Summary
- configure `grid_size` for gf180_mapped and sky130_mapped PDKs
- propagate grid size to `gdsfactory.config` when importing these modules
- document default grid behavior in snap-to-grid docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'mako')*